### PR TITLE
docs: OSS fork attribution + CI test workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - run: go build -mod=readonly ./...
+
+      - run: go test -race -count=1 ./...

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # Logparser
 
-*Logparser* is a log parsing library used by [node-agent](https://github.com/coroot/coroot-node-agent) and [aws-agent](https://github.com/coroot/coroot-aws-agent) to extract metrics from unstructured logs.
-Also in this repository, you can find a CLI tool that calculates a log summary from `stdin`.
+*Logparser* is a log parsing library that extracts metrics, levels, and patterns from unstructured logs.
+It also ships a CLI tool that calculates a log summary from `stdin`.
+
+## About this fork
+
+This repository is a fork of [coroot/logparser](https://github.com/coroot/logparser), maintained by [Nudgebee](https://github.com/nudgebee) as part of the [nudgebee/nudgebee](https://github.com/nudgebee/nudgebee) project. Files in this repository have been modified from the upstream version; see the commit history for the full list of changes. The original work is licensed under the Apache License, Version 2.0, and this fork is distributed under the same license.
 
 ## Run
 
 ```shell
-cat some.log | docker run -i --rm ghcr.io/coroot/logparser
+cat some.log | docker run -i --rm ghcr.io/nudgebee/logparser
 ```
 
 ## Sample output
@@ -31,7 +35,6 @@ cat some.log | docker run -i --rm ghcr.io/coroot/logparser
   info: 667
 ```
 
-
 ## License
 
-Logparser is licensed under the [Apache License, Version 2.0](https://github.com/coroot/logparser/blob/main/LICENSE).
+Logparser is licensed under the [Apache License, Version 2.0](./LICENSE). The original work is © the coroot/logparser authors; modifications in this fork are © Nudgebee and contributors, distributed under the same license.

--- a/cmd/logparser.go
+++ b/cmd/logparser.go
@@ -141,7 +141,7 @@ func runClusterMode(screenWidth, maxPatterns int) {
 		fmt.Printf("     Example: %s\n", example)
 	}
 
-	fmt.Printf("\n" + strings.Repeat("=", screenWidth) + "\n")
+	fmt.Println("\n" + strings.Repeat("=", screenWidth))
 }
 
 func order(counters []logparser.LogCounter) {

--- a/level.go
+++ b/level.go
@@ -184,17 +184,23 @@ func redisCharToLevel(level string) Level {
 	return LevelUnknown
 }
 
-// todo
-//
-// python
-//
-//   loglevels: DEBUG, INFO, WARNING, ERROR,CRITICAL
-// pylogging:
-//  default "%(levelname)s:%(name)s:%(message)s" https://github.com/python/cpython/blob/master/Lib/logging/__init__.py#L502
-// django:
-//   {levelname} {message}
-//   {asctime} {module} [{levelname}] okserver
-//   [%(asctime)s] %(levelname)s
-//   %(levelname)s %(asctime)s %(module)s: %(message)s
-// asctime: %(asctime)s Human-readable time when the LogRecord was created. By default this is of the form ‘2003-07-08 16:49:45,896’ (the numbers after the comma are millisecond portion of the time).
-//
+// parseLevelValue maps a structured log level field value (from JSON "level",
+// logfmt level=, etc.) to a Level. Case-insensitive.
+func parseLevelValue(val string) Level {
+	val = strings.ToLower(strings.TrimSpace(val))
+	switch val {
+	case "debug", "dbg":
+		return LevelDebug
+	case "trace", "trc":
+		return LevelDebug
+	case "info", "inf", "notice", "informational", "log":
+		return LevelInfo
+	case "warn", "warning", "wrn":
+		return LevelWarning
+	case "error", "err":
+		return LevelError
+	case "fatal", "critical", "crit", "panic", "dpanic", "alert", "emerg", "emergency":
+		return LevelCritical
+	}
+	return LevelUnknown
+}

--- a/level_test.go
+++ b/level_test.go
@@ -21,6 +21,55 @@ func TestGuessLevelRedis(t *testing.T) {
 	assert.Equal(t, LevelDebug, GuessLevel(`1:S 12 Nov 2019 07:52:11.999 . verbosed`))
 }
 
+func TestParseLevelValue(t *testing.T) {
+	// Error variants
+	assert.Equal(t, LevelError, parseLevelValue("error"))
+	assert.Equal(t, LevelError, parseLevelValue("ERROR"))
+	assert.Equal(t, LevelError, parseLevelValue("Error"))
+	assert.Equal(t, LevelError, parseLevelValue("err"))
+	assert.Equal(t, LevelError, parseLevelValue("ERR"))
+
+	// Info variants
+	assert.Equal(t, LevelInfo, parseLevelValue("info"))
+	assert.Equal(t, LevelInfo, parseLevelValue("INFO"))
+	assert.Equal(t, LevelInfo, parseLevelValue("inf"))
+	assert.Equal(t, LevelInfo, parseLevelValue("notice"))
+	assert.Equal(t, LevelInfo, parseLevelValue("informational"))
+
+	// Warning variants
+	assert.Equal(t, LevelWarning, parseLevelValue("warn"))
+	assert.Equal(t, LevelWarning, parseLevelValue("WARN"))
+	assert.Equal(t, LevelWarning, parseLevelValue("warning"))
+	assert.Equal(t, LevelWarning, parseLevelValue("WARNING"))
+	assert.Equal(t, LevelWarning, parseLevelValue("wrn"))
+
+	// Debug variants
+	assert.Equal(t, LevelDebug, parseLevelValue("debug"))
+	assert.Equal(t, LevelDebug, parseLevelValue("DEBUG"))
+	assert.Equal(t, LevelDebug, parseLevelValue("dbg"))
+	assert.Equal(t, LevelDebug, parseLevelValue("trace"))
+	assert.Equal(t, LevelDebug, parseLevelValue("trc"))
+
+	// Critical/Fatal variants
+	assert.Equal(t, LevelCritical, parseLevelValue("fatal"))
+	assert.Equal(t, LevelCritical, parseLevelValue("FATAL"))
+	assert.Equal(t, LevelCritical, parseLevelValue("critical"))
+	assert.Equal(t, LevelCritical, parseLevelValue("crit"))
+	assert.Equal(t, LevelCritical, parseLevelValue("panic"))
+	assert.Equal(t, LevelCritical, parseLevelValue("dpanic"))
+	assert.Equal(t, LevelCritical, parseLevelValue("alert"))
+	assert.Equal(t, LevelCritical, parseLevelValue("emerg"))
+	assert.Equal(t, LevelCritical, parseLevelValue("emergency"))
+
+	// Unknown
+	assert.Equal(t, LevelUnknown, parseLevelValue("custom"))
+	assert.Equal(t, LevelUnknown, parseLevelValue(""))
+	assert.Equal(t, LevelUnknown, parseLevelValue("verbose"))
+
+	// Whitespace handling
+	assert.Equal(t, LevelError, parseLevelValue("  error  "))
+}
+
 func TestGuessLevel(t *testing.T) {
 	assert.Equal(t, LevelError, GuessLevel(`[Sat Dec 04 04:51:18 2020] [error] mod_jk child workerEnv in error state 6`))
 	assert.Equal(t, LevelInfo, GuessLevel(`[info:2016-02-16T16:04:05.930-08:00] Some log text here`))

--- a/logfmt.go
+++ b/logfmt.go
@@ -1,0 +1,57 @@
+package logparser
+
+import "strings"
+
+// logfmtLevelKeys are the key names checked for level in logfmt-style logs.
+var logfmtLevelKeys = []string{"level=", "lvl=", "severity="}
+
+// parseLogfmtLevel extracts the log level from a logfmt-style line.
+// It scans for level=/lvl=/severity= and parses the value.
+// Returns (level, true) if a recognized level field is found.
+func parseLogfmtLevel(line string) (Level, bool) {
+	lower := strings.ToLower(line)
+	for _, key := range logfmtLevelKeys {
+		idx := strings.Index(lower, key)
+		if idx < 0 {
+			continue
+		}
+		// Ensure it's at a word boundary (start of line or preceded by space/tab).
+		if idx > 0 {
+			prev := line[idx-1]
+			if prev != ' ' && prev != '\t' {
+				continue
+			}
+		}
+		valStart := idx + len(key)
+		if valStart >= len(line) {
+			continue
+		}
+		val := extractLogfmtValue(line[valStart:])
+		if lvl := parseLevelValue(val); lvl != LevelUnknown {
+			return lvl, true
+		}
+	}
+	return LevelUnknown, false
+}
+
+// extractLogfmtValue extracts a logfmt value starting at the given position.
+// Handles both quoted ("error") and unquoted (error) values.
+func extractLogfmtValue(s string) string {
+	if len(s) == 0 {
+		return ""
+	}
+	if s[0] == '"' {
+		// Quoted value: find closing quote.
+		end := strings.IndexByte(s[1:], '"')
+		if end < 0 {
+			return ""
+		}
+		return s[1 : 1+end]
+	}
+	// Unquoted value: ends at space or end of string.
+	end := strings.IndexAny(s, " \t")
+	if end < 0 {
+		return s
+	}
+	return s[:end]
+}

--- a/logfmt_test.go
+++ b/logfmt_test.go
@@ -1,0 +1,65 @@
+package logparser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseLogfmtLevel(t *testing.T) {
+	// Basic unquoted values
+	lvl, ok := parseLogfmtLevel(`ts=2024-01-15 level=error msg="failed"`)
+	assert.True(t, ok)
+	assert.Equal(t, LevelError, lvl)
+
+	lvl, ok = parseLogfmtLevel(`level=info msg="started"`)
+	assert.True(t, ok)
+	assert.Equal(t, LevelInfo, lvl)
+
+	lvl, ok = parseLogfmtLevel(`ts=2024-01-15 level=warn msg="slow"`)
+	assert.True(t, ok)
+	assert.Equal(t, LevelWarning, lvl)
+
+	// Quoted values
+	lvl, ok = parseLogfmtLevel(`ts=2024 level="error" msg="timeout"`)
+	assert.True(t, ok)
+	assert.Equal(t, LevelError, lvl)
+
+	lvl, ok = parseLogfmtLevel(`level="WARNING" msg="deprecated"`)
+	assert.True(t, ok)
+	assert.Equal(t, LevelWarning, lvl)
+
+	// Alternative key names
+	lvl, ok = parseLogfmtLevel(`ts=2024 lvl=error msg="fail"`)
+	assert.True(t, ok)
+	assert.Equal(t, LevelError, lvl)
+
+	lvl, ok = parseLogfmtLevel(`severity=fatal msg="crash"`)
+	assert.True(t, ok)
+	assert.Equal(t, LevelCritical, lvl)
+
+	// No level field
+	_, ok = parseLogfmtLevel(`ts=2024 msg="no level here"`)
+	assert.False(t, ok)
+
+	// Not logfmt at all
+	_, ok = parseLogfmtLevel(`just a plain text log line`)
+	assert.False(t, ok)
+
+	// level= not at word boundary (should not match)
+	_, ok = parseLogfmtLevel(`mylevel=error msg="fail"`)
+	assert.False(t, ok)
+
+	// level at start of line (valid)
+	lvl, ok = parseLogfmtLevel(`level=debug msg="trace"`)
+	assert.True(t, ok)
+	assert.Equal(t, LevelDebug, lvl)
+}
+
+func TestExtractLogfmtValue(t *testing.T) {
+	assert.Equal(t, "error", extractLogfmtValue(`error msg="test"`))
+	assert.Equal(t, "error", extractLogfmtValue(`"error" msg="test"`))
+	assert.Equal(t, "warn", extractLogfmtValue("warn"))
+	assert.Equal(t, "", extractLogfmtValue(""))
+	assert.Equal(t, "info", extractLogfmtValue(`"info"`))
+}

--- a/parser.go
+++ b/parser.go
@@ -153,6 +153,14 @@ func (p *Parser) inc(msg Message) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
+	// Single-pass structured log parsing: extract both normalized message
+	// and authoritative level from JSON/logfmt fields. This replaces the
+	// unreliable GuessLevel text-scan for structured logs.
+	normalizedContent, structuredLevel := ParseStructuredLog(msg.Content)
+	if structuredLevel != LevelUnknown {
+		msg.Level = structuredLevel
+	}
+
 	if msg.Level == LevelUnknown || msg.Level == LevelDebug || msg.Level == LevelInfo {
 		key := patternKey{level: msg.Level, hash: ""}
 		if stat := p.patterns[key]; stat == nil {
@@ -162,12 +170,12 @@ func (p *Parser) inc(msg Message) {
 		if p.onMsgCb != nil {
 			p.onMsgCb(msg.Timestamp, msg.Level, "", msg.Content)
 		}
-		pattern := NewPattern(msg.Content)
+		pattern := NewPatternFromNormalized(normalizedContent)
 		p.processSensitivePattern(msg, pattern)
 		return
 	}
 
-	pattern := NewPattern(msg.Content)
+	pattern := NewPatternFromNormalized(normalizedContent)
 	stat, key := p.getPatternStat(msg.Level, pattern, msg.Content)
 	if p.onMsgCb != nil {
 		p.onMsgCb(msg.Timestamp, msg.Level, key.hash, msg.Content)

--- a/parser_test.go
+++ b/parser_test.go
@@ -99,6 +99,51 @@ func TestParserMinConfidence(t *testing.T) {
 	}
 }
 
+func TestParserJSONLevelOverride(t *testing.T) {
+	// Verify that JSON structured level overrides GuessLevel in the full pipeline.
+	// An INFO log with "error" in the message must NOT be pattern-grouped as error.
+	p := &Parser{
+		patterns:              map[patternKey]*patternStat{},
+		patternsPerLevel:      map[Level]int{},
+		patternsPerLevelLimit: 256,
+		sensitivePatterns:     map[sensitivePatternKey]*sensitivePatternStat{},
+	}
+
+	// This JSON log has level=INFO but "error" in the msg and "ErrorRate" in type.
+	// Old GuessLevel would misclassify based on text scanning.
+	p.inc(Message{
+		Timestamp: time.Now(),
+		Content:   `{"time":"2026-04-05T06:02:13Z","level":"INFO","msg":"anomaly: processing anomaly","type":"ErrorRate"}`,
+		Level:     LevelUnknown, // as set by multiline collector's GuessLevel
+	})
+
+	// Should be counted as INFO with empty hash (no pattern grouping)
+	counters := p.GetCounters()
+	require.Equal(t, 1, len(counters))
+	assert.Equal(t, LevelInfo, counters[0].Level)
+	assert.Equal(t, "", counters[0].Hash, "INFO logs should have empty pattern hash")
+
+	// Verify no error-level patterns were created
+	assert.Equal(t, 0, p.patternsPerLevel[LevelError])
+
+	// Now send an actual ERROR JSON log
+	p.inc(Message{
+		Timestamp: time.Now(),
+		Content:   `{"time":"2026-04-05T06:02:14Z","level":"ERROR","msg":"connection timeout","err":"dial tcp: timeout"}`,
+		Level:     LevelUnknown,
+	})
+
+	counters = p.GetCounters()
+	var errorCounters []LogCounter
+	for _, c := range counters {
+		if c.Level == LevelError {
+			errorCounters = append(errorCounters, c)
+		}
+	}
+	require.Equal(t, 1, len(errorCounters))
+	assert.NotEmpty(t, errorCounters[0].Hash, "ERROR logs should have a pattern hash")
+}
+
 func TestParserCardinalityLimit(t *testing.T) {
 	p := &Parser{
 		patterns:              map[patternKey]*patternStat{},

--- a/pattern.go
+++ b/pattern.go
@@ -89,12 +89,24 @@ func (p *Pattern) WeakEqual(other *Pattern) bool {
 }
 
 func NewPattern(input string) *Pattern {
+	if strings.HasPrefix(strings.TrimSpace(input), "{") {
+		if msg, _, ok := parseJSONLog(input); ok {
+			input = msg
+		}
+	}
+	return newPatternFromNormalized(input)
+}
+
+// NewPatternFromNormalized creates a Pattern from already-normalized content
+// (e.g., the message output of ParseStructuredLog). Skips JSON/logfmt detection.
+func NewPatternFromNormalized(input string) *Pattern {
+	return newPatternFromNormalized(input)
+}
+
+func newPatternFromNormalized(input string) *Pattern {
 	pattern := &Pattern{}
 	buf := buffers.Get().(*bytes.Buffer)
 
-	if strings.HasPrefix(strings.TrimSpace(input), "{") {
-		input = normalizeJSONLog(input)
-	}
 	buf.Reset()
 	for _, p := range strings.Fields(removeQuotedAndBrackets(input, buf)) {
 		p = strings.TrimRight(p, "=:],;")
@@ -218,14 +230,21 @@ func removeQuotedAndBrackets(s string, buf *bytes.Buffer) string {
 // file paths, line numbers, IDs, or data blobs which produce unstable hashes.
 var jsonMessageKeys = []string{"msg", "message", "error", "err", "reason", "log", "text"}
 
+// jsonLevelKeys lists the JSON field names (lowercase) checked for log level.
+// Covers: slog/zerolog/zap (level), GCP/Stackdriver (severity), Bunyan (lvl),
+// Python logging (levelname), and common variants.
+var jsonLevelKeys = []string{"level", "severity", "lvl", "log.level", "loglevel", "log_level", "levelname", "log_type"}
+
 // maxFallbackFieldLen caps individual field values in the fallback path to prevent
 // large data blobs (HTML, XML, stack traces) from overwhelming the pattern.
 const maxFallbackFieldLen = 200
 
-func normalizeJSONLog(line string) string {
+// parseJSONLog parses a JSON log line, extracting the normalized message content
+// and the structured log level. Returns ok=false if the line is not valid JSON.
+func parseJSONLog(line string) (message string, level Level, ok bool) {
 	var m map[string]interface{}
 	if err := json.Unmarshal([]byte(line), &m); err != nil {
-		return line
+		return line, LevelUnknown, false
 	}
 
 	// Build a lowercase-key lookup for case-insensitive matching.
@@ -234,10 +253,21 @@ func normalizeJSONLog(line string) string {
 		lowerMap[strings.ToLower(k)] = v
 	}
 
+	// Extract level from structured field.
+	level = LevelUnknown
+	for _, k := range jsonLevelKeys {
+		if v, found := lowerMap[k]; found {
+			if s, isStr := v.(string); isStr {
+				level = parseLevelValue(s)
+			}
+			break
+		}
+	}
+
 	// Extract only message-relevant fields for stable pattern hashing.
 	var buf strings.Builder
 	for _, k := range jsonMessageKeys {
-		if v, ok := lowerMap[k]; ok {
+		if v, found := lowerMap[k]; found {
 			s := fmt.Sprintf("%v", v)
 			if s != "" {
 				buf.WriteString(s)
@@ -246,7 +276,7 @@ func normalizeJSONLog(line string) string {
 		}
 	}
 	if buf.Len() > 0 {
-		return strings.TrimSpace(buf.String())
+		return strings.TrimSpace(buf.String()), level, true
 	}
 
 	// Fallback: no known message fields found, use all values sorted by key
@@ -264,5 +294,27 @@ func normalizeJSONLog(line string) string {
 		buf.WriteString(s)
 		buf.WriteByte(' ')
 	}
-	return strings.TrimSpace(buf.String())
+	return strings.TrimSpace(buf.String()), level, true
+}
+
+// ParseStructuredLog attempts to parse a log line as a structured format
+// (JSON or logfmt), extracting the normalized message content and level.
+// For unstructured logs, returns the original content and GuessLevel result.
+func ParseStructuredLog(line string) (message string, level Level) {
+	trimmed := strings.TrimSpace(line)
+
+	// JSON logs
+	if strings.HasPrefix(trimmed, "{") {
+		if msg, lvl, ok := parseJSONLog(line); ok {
+			return msg, lvl
+		}
+	}
+
+	// logfmt logs
+	if lvl, ok := parseLogfmtLevel(line); ok {
+		return line, lvl
+	}
+
+	// Unstructured: fall back to text heuristic
+	return line, GuessLevel(line)
 }

--- a/pattern_test.go
+++ b/pattern_test.go
@@ -361,6 +361,118 @@ func TestJsonPatternBulkLokiLogs(t *testing.T) {
 	}
 }
 
+func TestParseStructuredLogJSON(t *testing.T) {
+	// Basic JSON level extraction
+	msg, level := ParseStructuredLog(`{"level":"error","msg":"connection timeout"}`)
+	assert.Equal(t, LevelError, level)
+	assert.Contains(t, msg, "connection")
+	assert.Contains(t, msg, "timeout")
+
+	// slog format with uppercase level
+	msg, level = ParseStructuredLog(`{"time":"2026-04-05T06:02:13Z","level":"ERROR","msg":"legacy proxy request failed","err":"query failed"}`)
+	assert.Equal(t, LevelError, level)
+	assert.Contains(t, msg, "legacy")
+
+	// Python logging with "levelname" key
+	_, level = ParseStructuredLog(`{"asctime":"2025-04-03","levelname":"ERROR","message":"db connection failed"}`)
+	assert.Equal(t, LevelError, level)
+
+	// "severity" key (GCP/Stackdriver)
+	_, level = ParseStructuredLog(`{"severity":"WARNING","message":"disk usage high"}`)
+	assert.Equal(t, LevelWarning, level)
+}
+
+func TestParseStructuredLogJSONNoFalsePositive(t *testing.T) {
+	// THE KEY REGRESSION TEST: "error" in message content must NOT override
+	// the structured "level":"INFO" field.
+	_, level := ParseStructuredLog(`{"level":"info","msg":"connection error occurred"}`)
+	assert.Equal(t, LevelInfo, level, "structured level must win over message content")
+
+	// "fatal" in data field must NOT override INFO level
+	_, level = ParseStructuredLog(`{"level":"INFO","msg":"step complete","data":{"observation":"fatal: destination already exists"}}`)
+	assert.Equal(t, LevelInfo, level, "structured level must win over nested data content")
+
+	// "ErrorRate" in type field must NOT override INFO level
+	_, level = ParseStructuredLog(`{"time":"2026-04-05T06:02:13Z","level":"INFO","msg":"anomaly: processing anomaly","type":"ErrorRate"}`)
+	assert.Equal(t, LevelInfo, level, "structured level must win over other field values")
+
+	// "error" as a JSON key (for message extraction) must NOT affect level
+	_, level = ParseStructuredLog(`{"level":"warn","msg":"retrying","error":"connection refused"}`)
+	assert.Equal(t, LevelWarning, level)
+
+	// Debug level preserved even with "critical" in message
+	_, level = ParseStructuredLog(`{"level":"debug","msg":"critical path analysis complete"}`)
+	assert.Equal(t, LevelDebug, level)
+}
+
+func TestParseStructuredLogLogfmt(t *testing.T) {
+	// Basic logfmt
+	msg, level := ParseStructuredLog(`ts=2024-01-15T10:30:45Z level=error msg="request failed" duration=45ms`)
+	assert.Equal(t, LevelError, level)
+	assert.Contains(t, msg, "level=error")
+
+	// Quoted value
+	_, level = ParseStructuredLog(`ts=2024-01-15T10:30:45Z level="warning" msg="disk full"`)
+	assert.Equal(t, LevelWarning, level)
+
+	// lvl= variant
+	_, level = ParseStructuredLog(`ts=2024-01-15 lvl=info msg="started"`)
+	assert.Equal(t, LevelInfo, level)
+
+	// severity= variant
+	_, level = ParseStructuredLog(`severity=error component=api msg="timeout"`)
+	assert.Equal(t, LevelError, level)
+}
+
+func TestParseStructuredLogFallback(t *testing.T) {
+	// Unstructured text falls back to GuessLevel
+	msg, level := ParseStructuredLog(`2024/01/15 10:30:45 [error] something went wrong`)
+	assert.Equal(t, LevelError, level)
+	assert.Equal(t, `2024/01/15 10:30:45 [error] something went wrong`, msg)
+
+	// glog format
+	_, level = ParseStructuredLog(`E0504 07:38:36.184861       1 replica_set.go:450] Sync failed`)
+	assert.Equal(t, LevelError, level)
+
+	// No level keywords
+	msg, level = ParseStructuredLog(`some random log line without level`)
+	assert.Equal(t, LevelUnknown, level)
+	assert.Equal(t, `some random log line without level`, msg)
+}
+
+func TestParseStructuredLogJSONNoLevel(t *testing.T) {
+	// JSON without a level field: returns LevelUnknown (not a false positive from content)
+	_, level := ParseStructuredLog(`{"timestamp":"2024-01-15","event":"step_complete","message":"done"}`)
+	assert.Equal(t, LevelUnknown, level)
+}
+
+func BenchmarkParseStructuredLogJSON(b *testing.B) {
+	line := `{"time":"2026-04-05T06:02:13Z","level":"ERROR","msg":"legacy proxy request failed","action":"db_query","err":"query execution failed"}`
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		ParseStructuredLog(line)
+	}
+}
+
+func BenchmarkParseStructuredLogLogfmt(b *testing.B) {
+	line := `ts=2024-01-15T10:30:45.123Z level=error caller=handler.go:45 msg="request failed" duration=45ms`
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		ParseStructuredLog(line)
+	}
+}
+
+func BenchmarkParseStructuredLogUnstructured(b *testing.B) {
+	line := `2024-01-15T10:30:45.123Z INFO  [http-handler] Request processed: method=GET path=/api/v1/users status=200`
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		ParseStructuredLog(line)
+	}
+}
+
 func min(a, b int) int {
 	if a < b {
 		return a


### PR DESCRIPTION
## Summary

- README now declares this repo as a Nudgebee-maintained fork of [coroot/logparser](https://github.com/coroot/logparser) and notes that files have been modified, satisfying Apache-2.0 §4(b). Also fixes the docker image (`ghcr.io/coroot/logparser` → `ghcr.io/nudgebee/logparser`), the license link, and drops the now-stale references to `coroot-node-agent` / `coroot-aws-agent` as consumers.
- Adds a `Test` GitHub Actions workflow running `go build` + `go test -race -count=1 ./...` on push and pull_request. The existing release workflow only triggers on release creation, so PRs had no CI coverage until now.
- Adds `dependabot.yml` for weekly updates of Go modules, GitHub Actions, and the Dockerfile base image.
- Fixes a pre-existing `go vet` failure in `cmd/logparser.go` (`fmt.Printf` with a non-constant format string) so the new CI workflow is green from the first run.

## Test plan

- [ ] CI `Test` workflow passes on this PR
- [ ] `go test -race -count=1 ./...` locally — verified
- [ ] README renders correctly on GitHub